### PR TITLE
MySQLRoute: Add EnableDecoding field in the spec

### DIFF
--- a/apis/gateway/v1alpha1/mysqlroute_types.go
+++ b/apis/gateway/v1alpha1/mysqlroute_types.go
@@ -97,6 +97,11 @@ type MySQLRouteSpec struct {
 	// +kubebuilder:validation:MaxItems=16
 	Rules []MySQLRouteRule `json:"rules"`
 
+	// Controls whether SQL statements received in Frontend Query messages
+	// are decoded. Defaults to false.
+	// +optional
+	EnableDecoding bool `json:"enableDecoding,omitempty"`
+
 	// +optional
 	Telemetry TelemetryRefence `json:"telemetry,omitempty"`
 }

--- a/config/crd/bases/gateway.voyagermesh.com_mysqlroutes.yaml
+++ b/config/crd/bases/gateway.voyagermesh.com_mysqlroutes.yaml
@@ -51,6 +51,11 @@ spec:
           spec:
             description: Spec defines the desired state of MySQLRoute.
             properties:
+              enableDecoding:
+                description: |-
+                  Controls whether SQL statements received in Frontend Query messages
+                  are decoded. Defaults to false.
+                type: boolean
               hostnames:
                 description: |-
                   Hostnames defines a set of SNI names that should match against the


### PR DESCRIPTION
Add a new field in the Spec to control the SQL statement decode in the filter